### PR TITLE
Small typo on opts object example. README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Additional options that can be passed, with default values shown:
 ```javascript
 var opts = {
   width: 128, // screen width
-  height; 32, // screen height
+  height: 32, // screen height
   address: 0x3C, // Pass I2C address of screen if it is not the default of 0x3C
   device: '/dev/i2c-1', // Pass your i2c device here if it is not /dev/i2c-1
   microview: true, // set to true if you have a microview display


### PR DESCRIPTION
Small typo on opts object example. Replacing ; with :