### PR TITLE
Make display much faster

### DIFF
--- a/oled.js
+++ b/oled.js
@@ -11,6 +11,7 @@ var Oled = function(opts) {
   this.ADDRESS = opts.address || 0x3C;
   this.DEVICE = opts.device || '/dev/i2c-1';
   this.MICROVIEW = opts.microview || false;
+  this.DATA_SIZE = opts.datasize || 32;
 
   // create command buffers
   this.DISPLAY_OFF = 0xAE;
@@ -128,7 +129,7 @@ Oled.prototype._transfer = function(type, val) {
 
 Oled.prototype._transferData = function(val) {
   let control = 0x40;
-  var size = 32;
+  var size = this.DATA_SIZE;
   for (var i=0; i<val.length; i+=size) {
       var smallarray = val.slice(i,i+size);
       this.wire.writeBytes(control, smallarray, function () {});

--- a/oled.js
+++ b/oled.js
@@ -11,7 +11,7 @@ var Oled = function(opts) {
   this.ADDRESS = opts.address || 0x3C;
   this.DEVICE = opts.device || '/dev/i2c-1';
   this.MICROVIEW = opts.microview || false;
-  this.DATA_SIZE = opts.datasize || 32;
+  this.DATA_SIZE = opts.datasize || 16;
 
   // create command buffers
   this.DISPLAY_OFF = 0xAE;

--- a/oled.js
+++ b/oled.js
@@ -306,9 +306,6 @@ Oled.prototype.update = function() {
     }
 
     // write buffer data
-    /*for (v = 0; v < bufferLen; v += 1) {
-      this._transfer('data', this.buffer[v]);
-    }*/
     this._transferData(this.buffer);
 
   }.bind(this));
@@ -470,15 +467,12 @@ Oled.prototype._updateDirtyBytes = function(byteArray) {
     // send byte, then move on to next byte
     for (vp = pageStart; vp <= pageEnd; vp += 1) {
       for (vc = colStart; vc <= colEnd; vc += 1) {
-        //this._transfer('data', this.buffer[this.WIDTH * vp + vc]);
         bytes[idx] = this.buffer[this.WIDTH * vp + vc];
         idx++;
       }
     }
 
     this._transferData(bytes);
-
-
 
   }.bind(this));
 


### PR DESCRIPTION
By sending the data in chunks instead of single bytes the transfer and consequently the graphics display is much faster.

This PR also includes the fix for the tick / setTimeout issue.